### PR TITLE
fix(db): forzar client_encoding UTF8 y corregir variables de conexión

### DIFF
--- a/src/modelsSequelize/database.ts
+++ b/src/modelsSequelize/database.ts
@@ -2,11 +2,12 @@ const { Sequelize } = require('sequelize');
 
 export const sequelize = new Sequelize(
   {
-    database: process.env.DB_USER || 'fuagenerator',
-    username: process.env.DB_PASSWORD || 'fuagenerator',
-    password: process.env.DB_NAME || 'fuagenerator',
+    database: process.env.DB_NAME || 'fuagenerator',
+    username: process.env.DB_USER || 'fuagenerator',
+    password: process.env.DB_PASSWORD || 'fuagenerator',
     host: process.env.DB_HOST || 'localhost',
     port: process.env.DB_PORT || '5433',
-    dialect:'postgres',
+    dialect: 'postgres',
+    dialectOptions: { client_encoding: 'UTF8' },
   }
 );


### PR DESCRIPTION
## Problema
Las tildes/caracteres acentuados en español se rompían en el HTML renderizado.

## Causa raíz
El schema FUA (con labels como *"Ficha Única de Atención"*) se guarda como `TEXT` en Postgres. La conexión Sequelize **no fijaba `client_encoding`**, provocando mojibake al guardar/leer texto acentuado. El render demo (desde archivo `.jsonc`) salía bien; el render real (desde BD) se rompía.

Además, las variables de conexión estaban **cruzadas**: `database` apuntaba a `DB_USER`, `username` a `DB_PASSWORD` y `password` a `DB_NAME`.

## Cambios
- `dialectOptions: { client_encoding: 'UTF8' }` en la conexión.
- Corregido el mapeo `database`/`username`/`password` → `DB_NAME`/`DB_USER`/`DB_PASSWORD`.

## Verificado
- El encoder de payload (encrypt/base64/decrypt) se descartó: round-trip con tildes correcto.
- Lecturas de archivos (`utf-8`), `<meta charset>` y respuesta Express ya eran correctas.

## Nota
Si hay filas ya guardadas con encoding corrupto, requerirán re-importación (este fix evita el problema de aquí en adelante).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sihsalus/codesmith/Generador-de-FUA/pr/8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->