### PR TITLE
fix(ci): corregir permiso duplicado que invalida docker-publish.yml

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,7 +15,6 @@ permissions:
   actions: write
   contents: read
   packages: write
-  actions: write
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
El workflow `docker-publish.yml` en main quedó inválido: la clave `actions: write` aparecía dos veces en `permissions` → *'actions is already defined' (Line 18)*.

Se elimina la línea duplicada (se conserva un único `actions: write`). YAML validado.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sihsalus/codesmith/Generador-de-FUA/pr/10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->