### PR TITLE
fix: gate production image on a real FUA smoke

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -53,14 +53,30 @@ jobs:
             type=sha,format=short
             type=raw,value=latest,enable={{is_default_branch}}
 
-      - name: Build and push
+      - name: Build smoke candidate
         uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile
-          # En PRs solo se construye (valida el Dockerfile); en main/tags se publica.
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
+          push: false
+          load: true
+          tags: fua-generator-smoke:${{ github.sha }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Smoke PostgreSQL and generate a FUA PDF
+        env:
+          FUA_SMOKE_IMAGE: fua-generator-smoke:${{ github.sha }}
+        run: bash scripts/smoke-container.sh
+
+      - name: Publish verified image
+        if: github.event_name != 'pull_request'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,5 +40,10 @@ WORKDIR /FUA_Generator
 COPY package.json /FUA_Generator
 RUN npm install
 COPY . /FUA_Generator
+
+# Keep ts-node available during the current source-based startup while making
+# Express and the application run with production error handling.
+ENV NODE_ENV=production
+
 EXPOSE 3000
 CMD ["npm", "start"]

--- a/docker-compose.smoke.yml
+++ b/docker-compose.smoke.yml
@@ -1,0 +1,12 @@
+services:
+  db:
+    # Match the PostgreSQL major version used by SIHSALUS.
+    image: postgres:17
+
+  app:
+    environment:
+      NODE_ENV: production
+      TOKEN: ${FUA_SMOKE_TOKEN}
+      SECRET_KEY: ${FUA_SMOKE_SECRET_KEY}
+      HMAC_SECRET: ${FUA_SMOKE_HMAC_SECRET}
+      ENCRYPTION_KEY: ${FUA_SMOKE_ENCRYPTION_KEY}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       db:
         condition: service_healthy
     environment:
+      NODE_ENV: production
       DB_HOST: db
       DB_USER: ${FuaGen_DB__USER:-fuagenerator}
       DB_PASSWORD: ${FuaGen_DB_PASSWORD:-fuagenerator}

--- a/scripts/smoke-container.sh
+++ b/scripts/smoke-container.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+project_name="fua-smoke-${GITHUB_RUN_ID:-$$}-${GITHUB_RUN_ATTEMPT:-0}"
+temporary_directory="$(mktemp -d)"
+headers_path="${temporary_directory}/headers.txt"
+pdf_path="${temporary_directory}/fua-smoke.pdf"
+smoke_token="ci-smoke-token-not-secret"
+export FUA_SMOKE_TOKEN="${smoke_token}"
+export FUA_SMOKE_SECRET_KEY="ci-smoke-pdf-hmac-not-secret"
+export FUA_SMOKE_HMAC_SECRET="ci-smoke-version-hmac"
+export FUA_SMOKE_ENCRYPTION_KEY="ci-smoke-key"
+compose=(
+  docker compose
+  --project-name "${project_name}"
+  --file docker-compose.yml
+  --file docker-compose.smoke.yml
+)
+
+cleanup() {
+  exit_code=$?
+  trap - EXIT
+
+  if (( exit_code != 0 )); then
+    "${compose[@]}" ps || true
+    "${compose[@]}" logs --no-color || true
+  fi
+
+  "${compose[@]}" down --volumes --remove-orphans >/dev/null 2>&1 || true
+  rm -rf "${temporary_directory}"
+  exit "${exit_code}"
+}
+trap cleanup EXIT
+
+if [[ -n "${FUA_SMOKE_IMAGE:-}" ]]; then
+  docker image inspect "${FUA_SMOKE_IMAGE}" >/dev/null 2>&1 || docker pull "${FUA_SMOKE_IMAGE}"
+  docker tag "${FUA_SMOKE_IMAGE}" "${project_name}-app:latest"
+  "${compose[@]}" up --no-build --wait --wait-timeout 240
+else
+  "${compose[@]}" up --build --wait --wait-timeout 240
+fi
+
+database_table_oids() {
+  "${compose[@]}" exec -T db \
+    psql --username fuagenerator --dbname fuagenerator --tuples-only --no-align \
+    --command "SELECT c.relname || ':' || c.oid FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'public' AND c.relkind = 'r' ORDER BY c.relname;"
+}
+
+wait_for_health() {
+  for _attempt in $(seq 1 60); do
+    if curl --fail --silent http://localhost:3000/health >/dev/null; then
+      return 0
+    fi
+    sleep 2
+  done
+
+  echo "The FUA service did not become healthy after restart." >&2
+  return 1
+}
+
+table_oids_before_restart="$(database_table_oids)"
+if [[ -z "${table_oids_before_restart}" ]]; then
+  echo "The startup sync did not create any application tables." >&2
+  exit 1
+fi
+
+"${compose[@]}" restart app
+wait_for_health
+
+table_oids_after_restart="$(database_table_oids)"
+if [[ "${table_oids_before_restart}" != "${table_oids_after_restart}" ]]; then
+  echo "Database table identities changed after application restart." >&2
+  exit 1
+fi
+
+"${compose[@]}" exec -T app node -e '
+  const express = require("express");
+  if (process.env.NODE_ENV !== "production" || express().get("env") !== "production") {
+    throw new Error(`Expected production runtime, got NODE_ENV=${process.env.NODE_ENV}`);
+  }
+'
+
+format_response_path="${temporary_directory}/format-response.json"
+format_status="$(curl \
+  --silent \
+  --show-error \
+  --max-time 60 \
+  --output "${format_response_path}" \
+  --write-out '%{http_code}' \
+  --header "fuagentoken: ${smoke_token}" \
+  --form 'formatPayload=@src/utils/FUA_Schema_Examples/FUA_1.0.jsonc;type=application/json' \
+  --form 'name=CI Smoke FUA' \
+  --form 'createdBy=ci-smoke' \
+  http://localhost:3000/ws/FUAFormat/)"
+
+if [[ "${format_status}" != '201' ]]; then
+  echo "Creating the FUA format returned HTTP ${format_status}." >&2
+  cat "${format_response_path}" >&2
+  exit 1
+fi
+
+format_uuid="$(jq --exit-status --raw-output '.uuid' "${format_response_path}")"
+create_fua_path="${temporary_directory}/create-fua.json"
+jq --null-input \
+  --arg format_uuid "${format_uuid}" \
+  '{
+    payload: {
+      uuid: "11111111-1111-4111-8111-111111111111",
+      startDatetime: "2026-01-02T03:04:05.000+0000",
+      visitType: {
+        name: "Consulta Ambulatoria",
+        display: "Consulta Ambulatoria"
+      },
+      patient: {
+        identifiers: [{display: "DNI = 00000000"}],
+        person: {gender: "F"}
+      },
+      encounters: []
+    },
+    schemaType: "openmrs-visit-v1",
+    outputType: "application/pdf",
+    FUAFormatFromSchemaId: $format_uuid,
+    createdBy: "ci-smoke"
+  }' > "${create_fua_path}"
+
+fua_response_path="${temporary_directory}/fua-response.json"
+fua_status="$(curl \
+  --silent \
+  --show-error \
+  --max-time 180 \
+  --output "${fua_response_path}" \
+  --write-out '%{http_code}' \
+  --header "fuagentoken: ${smoke_token}" \
+  --header 'content-type: application/json' \
+  --data-binary "@${create_fua_path}" \
+  http://localhost:3000/ws/FUAFromVisit/)"
+
+if [[ "${fua_status}" != '201' ]]; then
+  echo "Creating the FUA returned HTTP ${fua_status}." >&2
+  cat "${fua_response_path}" >&2
+  exit 1
+fi
+
+fua_uuid="$(jq --exit-status --raw-output '.uuid' "${fua_response_path}")"
+render_path="${temporary_directory}/fua.html"
+curl \
+  --fail \
+  --silent \
+  --show-error \
+  --max-time 60 \
+  --request POST \
+  --header "fuagentoken: ${smoke_token}" \
+  --output "${render_path}" \
+  "http://localhost:3000/ws/FUAFromVisit/${fua_uuid}/render"
+
+grep --fixed-strings --quiet 'FORMATO UNICO DE ATENCIÓN - FUA' "${render_path}"
+grep --fixed-strings --quiet '00000066' "${render_path}"
+grep --fixed-strings --quiet '7-00000000' "${render_path}"
+
+pdf_status="$(curl \
+  --silent \
+  --show-error \
+  --max-time 180 \
+  --request POST \
+  --dump-header "${headers_path}" \
+  --output "${pdf_path}" \
+  --write-out '%{http_code}' \
+  --header "fuagentoken: ${smoke_token}" \
+  "http://localhost:3000/ws/FUAFromVisit/${fua_uuid}/generatePDF")"
+
+if [[ "${pdf_status}" != '200' ]]; then
+  echo "Generating the FUA PDF returned HTTP ${pdf_status}." >&2
+  cat "${pdf_path}" >&2
+  exit 1
+fi
+
+if ! grep -Eiq '^content-type:[[:space:]]*application/pdf' "${headers_path}"; then
+  echo "The FUA endpoint did not return application/pdf." >&2
+  exit 1
+fi
+
+if [[ "$(head -c 5 "${pdf_path}")" != '%PDF-' ]]; then
+  echo "The generated artifact does not have a PDF signature." >&2
+  exit 1
+fi
+
+if (( $(wc -c < "${pdf_path}") <= 10000 )); then
+  echo "The generated FUA PDF is unexpectedly small." >&2
+  exit 1
+fi
+
+app_container_id="$("${compose[@]}" ps --quiet app)"
+if [[ -z "${app_container_id}" ]]; then
+  echo "The FUA application container is not running." >&2
+  exit 1
+fi
+
+docker cp "${pdf_path}" "${app_container_id}:/tmp/fua-smoke.pdf"
+"${compose[@]}" exec -T app node -e '
+  const fs = require("fs");
+  const { PDFDocument } = require("pdf-lib");
+
+  void PDFDocument.load(fs.readFileSync("/tmp/fua-smoke.pdf"))
+    .then((pdf) => {
+      if (pdf.getPageCount() < 1) {
+        throw new Error("The generated FUA has no pages.");
+      }
+
+      const subject = pdf.getSubject() || "";
+      if (!/^SIH\.SALUS - HASH: [a-f0-9]{64}$/.test(subject)) {
+        throw new Error(`The generated FUA has invalid signature metadata: ${subject}`);
+      }
+
+      console.log(`Validated FUA PDF: ${pdf.getPageCount()} page(s).`);
+    })
+    .catch((error) => {
+      console.error(error);
+      process.exit(1);
+    });
+'
+
+verification_response_path="${temporary_directory}/verification-response.json"
+curl \
+  --fail \
+  --silent \
+  --show-error \
+  --max-time 60 \
+  --header "fuagentoken: ${smoke_token}" \
+  --form "pdf=@${pdf_path};type=application/pdf" \
+  --output "${verification_response_path}" \
+  http://localhost:3000/ws/FUAFromVisit/hashSignatureVerification
+jq --exit-status '.result == true' "${verification_response_path}" >/dev/null
+
+echo "Generated FUA size: $(wc -c < "${pdf_path}") bytes"
+sha256sum "${pdf_path}"

--- a/scripts/smoke-container.sh
+++ b/scripts/smoke-container.sh
@@ -32,8 +32,29 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# Registries occasionally return transient 5xx/timeout errors on pulls. Retry so a
+# flaky registry does not falsely block the production publish gate.
+pull_with_retry() {
+  local reference="$1"
+  local attempt
+  for attempt in 1 2 3 4 5; do
+    if docker pull "${reference}"; then
+      return 0
+    fi
+    echo "Pulling ${reference} failed (attempt ${attempt}/5); retrying..." >&2
+    sleep $(( attempt * 5 ))
+  done
+  echo "Could not pull ${reference} after multiple attempts." >&2
+  return 1
+}
+
+# Pre-pull the database image (with retries) so the implicit pull performed by
+# `docker compose up` cannot fail the smoke on a transient registry error.
+db_image="$("${compose[@]}" config --format json | jq --exit-status --raw-output '.services.db.image')"
+pull_with_retry "${db_image}"
+
 if [[ -n "${FUA_SMOKE_IMAGE:-}" ]]; then
-  docker image inspect "${FUA_SMOKE_IMAGE}" >/dev/null 2>&1 || docker pull "${FUA_SMOKE_IMAGE}"
+  docker image inspect "${FUA_SMOKE_IMAGE}" >/dev/null 2>&1 || pull_with_retry "${FUA_SMOKE_IMAGE}"
   docker tag "${FUA_SMOKE_IMAGE}" "${project_name}-app:latest"
   "${compose[@]}" up --no-build --wait --wait-timeout 240
 else


### PR DESCRIPTION
## Resumen

- fija `NODE_ENV=production` en la imagen y Compose
- construye una imagen candidata local antes de publicar
- levanta PostgreSQL 17 en CI y valida `/health`
- reinicia la app y comprueba que los OID de las tablas no cambien
- crea un formato y un FUA sintético por las rutas reales
- renderiza, genera y vuelve a verificar el PDF firmado
- publica en GHCR únicamente después de que el smoke termine correctamente

## Seguridad y contratos

No cambia endpoints, payloads ni variables existentes. El smoke usa únicamente credenciales y datos ficticios, no conserva el PDF como artifact y limpia contenedores/volúmenes del runner.

Follow-up de sihsalus#184 y Generador-de-FUA#14.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sihsalus/codesmith/Generador-de-FUA/pr/15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->