### PR TITLE
fix(runtime): make database startup production-safe

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 node_modules
+dist
 npm-debug.log
 .env
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -21,3 +21,30 @@ Este proyecto es una API en Node.js (Express) construida con TypeScript que gene
 - Postgre SQL:  docker run --name sih-salus-fua-db -e POSTGRES_USER=fuagenerator -e POSTGRES_PASSWORD=fuagenerator  -e POSTGRES_DB=fuagenerator -p 5433:5432 -d postgres:15
 
 Test
+
+## Configuración de PostgreSQL
+
+El servicio usa las variables canónicas sin intercambiar sus significados:
+
+| Variable | Uso |
+| --- | --- |
+| `DB_NAME` | Nombre de la base de datos |
+| `DB_USER` | Usuario de PostgreSQL |
+| `DB_PASSWORD` | Contraseña de PostgreSQL |
+| `DB_HOST` | Host de PostgreSQL |
+| `DB_PORT` | Puerto de PostgreSQL |
+
+El arranque sincroniza únicamente las tablas faltantes. Nunca elimina ni
+recrea tablas existentes.
+
+## Salud del servicio
+
+`GET /health` comprueba también la conexión con PostgreSQL:
+
+- devuelve `200` con `{ "status": "ok" }` cuando la aplicación y la base
+  están disponibles;
+- devuelve `503` con `{ "status": "unavailable" }` cuando PostgreSQL no
+  está disponible, sin exponer detalles internos.
+
+El entorno local puede iniciarse con `docker compose up --build` y espera a
+que PostgreSQL esté listo antes de iniciar la aplicación.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,15 +2,20 @@ services:
   db:
     image: postgres:15
     environment:
-      POSTGRES_USER: ${FuaGen_DB__USER:-fuagenerator}
-      POSTGRES_PASSWORD: ${FuaGen_DB_PASSWORD:-fuagenerator}
-      POSTGRES_DB: ${FuaGen_DB_NAME:-fuagenerator}
+      POSTGRES_USER: ${DB_USER:-fuagenerator}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:-fuagenerator}
+      POSTGRES_DB: ${DB_NAME:-fuagenerator}
     volumes:
       - FuaGenerator_DB_Data:/var/lib/postgresql/data
      # - ./init.sql:/docker-entrypoint-initdb.d/init.sql  # Optional initialization
     ports:
       - "5433:5432"
-
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U \"$${POSTGRES_USER}\" -d \"$${POSTGRES_DB}\""]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
 
   app:
     build: .
@@ -19,9 +24,9 @@ services:
         condition: service_healthy
     environment:
       DB_HOST: db
-      DB_USER: ${DB_USER:-postgres}
-      DB_PASSWORD: ${DB_PASSWORD:-postgres}
-      DB_NAME: ${DB_NAME:-mydatabase}
+      DB_USER: ${DB_USER:-fuagenerator}
+      DB_PASSWORD: ${DB_PASSWORD:-fuagenerator}
+      DB_NAME: ${DB_NAME:-fuagenerator}
       DB_PORT: 5432
     ports:
       - "3000:3000"

--- a/src/config/databaseConfig.test.ts
+++ b/src/config/databaseConfig.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from '@jest/globals';
+import {
+  DATABASE_SYNC_OPTIONS,
+  getDatabaseConfig,
+} from './databaseConfig';
+
+describe('database configuration', () => {
+  test('maps canonical environment variables without crossing credentials', () => {
+    const config = getDatabaseConfig({
+      DB_NAME: 'fua_database',
+      DB_USER: 'fua_user',
+      DB_PASSWORD: 'fua_password',
+      DB_HOST: 'fua-db',
+      DB_PORT: '5432',
+    });
+
+    expect(config).toMatchObject({
+      database: 'fua_database',
+      username: 'fua_user',
+      password: 'fua_password',
+      host: 'fua-db',
+      port: 5432,
+      dialect: 'postgres',
+    });
+  });
+
+  test('rejects an invalid database port', () => {
+    expect(() => getDatabaseConfig({ DB_PORT: 'invalid' })).toThrow(
+      'DB_PORT must be an integer between 1 and 65535.',
+    );
+  });
+
+  test('never enables destructive synchronization', () => {
+    expect(DATABASE_SYNC_OPTIONS).toEqual({ force: false });
+  });
+});

--- a/src/config/databaseConfig.ts
+++ b/src/config/databaseConfig.ts
@@ -1,0 +1,22 @@
+import type { Options } from 'sequelize';
+
+export const DATABASE_SYNC_OPTIONS = Object.freeze({ force: false } as const);
+
+export function getDatabaseConfig(
+  environment: NodeJS.ProcessEnv = process.env,
+): Options {
+  const port = Number(environment.DB_PORT ?? '5433');
+
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error('DB_PORT must be an integer between 1 and 65535.');
+  }
+
+  return {
+    database: environment.DB_NAME || 'fuagenerator',
+    username: environment.DB_USER || 'fuagenerator',
+    password: environment.DB_PASSWORD || 'fuagenerator',
+    host: environment.DB_HOST || 'localhost',
+    port,
+    dialect: 'postgres',
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import puppeteer, { Browser } from "puppeteer";
 
 // Sequelize and models
 import { sequelize } from './modelsSequelize/database';
+import { DATABASE_SYNC_OPTIONS } from './config/databaseConfig';
 
 // Services
 import { getPatient } from './services/fhirService';
@@ -25,6 +26,7 @@ import { getPatient } from './services/fhirService';
 // Import Routes
 import globalRouter from './routes/indexRoutes';
 import { createDemoFormat } from './utils/utils';
+import { createHealthHandler } from './routes/healthRoute';
 import { loggerInstance } from './middleware/logger/models/typescript/Logger';
 import { Log } from './middleware/logger/models/typescript/Log';
 import { Logger_LogLevel } from './utils/LegLevelEnum';
@@ -50,7 +52,7 @@ sequelize.authenticate()
   console.log(`\nConnection has been established with database successfully.\n`);  
   // Syncronize models
   console.log('\n Syncronizing models ... \n');
-  sequelize.sync({ force: true })
+  sequelize.sync(DATABASE_SYNC_OPTIONS)
   //sequelize.sync({ alter: true })
   .then( () : void => {
     console.log('\nEnded syncronizing models ...\n');
@@ -85,6 +87,8 @@ app.use(express.json());
 
 // Importing Routes
 app.use('/ws', globalRouter);
+
+app.get('/health', createHealthHandler(() => sequelize.authenticate()));
 
 
 // Comentario para marcelo: Ya funciona el getter del patients a través de la API de OpenMRS, faltarian ajustar algunas cosas como el cors y la seguridad, revisar servicios de getPatient.

--- a/src/modelsSequelize/database.ts
+++ b/src/modelsSequelize/database.ts
@@ -1,12 +1,4 @@
 const { Sequelize } = require('sequelize');
+import { getDatabaseConfig } from '../config/databaseConfig';
 
-export const sequelize = new Sequelize(
-  {
-    database: process.env.DB_USER || 'fuagenerator',
-    username: process.env.DB_PASSWORD || 'fuagenerator',
-    password: process.env.DB_NAME || 'fuagenerator',
-    host: process.env.DB_HOST || 'localhost',
-    port: process.env.DB_PORT || '5433',
-    dialect:'postgres',
-  }
-);
+export const sequelize = new Sequelize(getDatabaseConfig());

--- a/src/routes/healthRoute.test.ts
+++ b/src/routes/healthRoute.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from '@jest/globals';
+import express from 'express';
+import { AddressInfo } from 'node:net';
+import { createHealthHandler } from './healthRoute';
+import type { DatabaseHealthcheck } from './healthRoute';
+
+async function requestHealth(checkDatabase: DatabaseHealthcheck) {
+  const app = express();
+  app.get('/health', createHealthHandler(checkDatabase));
+
+  const server = app.listen(0, '127.0.0.1');
+  await new Promise<void>((resolve, reject) => {
+    server.once('listening', resolve);
+    server.once('error', reject);
+  });
+
+  try {
+    const address = server.address() as AddressInfo;
+    const response = await fetch(
+      `http://127.0.0.1:${address.port}/health`,
+    );
+
+    return {
+      status: response.status,
+      body: await response.json(),
+    };
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
+  }
+}
+
+describe('health route', () => {
+  test('reports healthy when PostgreSQL is reachable', async () => {
+    const result = await requestHealth(async () => undefined);
+
+    expect(result).toEqual({ status: 200, body: { status: 'ok' } });
+  });
+
+  test('reports unavailable without exposing database errors', async () => {
+    const result = await requestHealth(async () => {
+      throw new Error('synthetic database failure');
+    });
+
+    expect(result).toEqual({
+      status: 503,
+      body: { status: 'unavailable' },
+    });
+  });
+});

--- a/src/routes/healthRoute.ts
+++ b/src/routes/healthRoute.ts
@@ -1,0 +1,16 @@
+import { RequestHandler } from 'express';
+
+export type DatabaseHealthcheck = () => Promise<unknown>;
+
+export function createHealthHandler(
+  checkDatabase: DatabaseHealthcheck,
+): RequestHandler {
+  return async (_request, response) => {
+    try {
+      await checkDatabase();
+      response.status(200).json({ status: 'ok' });
+    } catch {
+      response.status(503).json({ status: 'unavailable' });
+    }
+  };
+}


### PR DESCRIPTION
## Summary

- map `DB_NAME`, `DB_USER`, and `DB_PASSWORD` to their canonical Sequelize fields;
- disable destructive Sequelize synchronization at startup;
- add `GET /health`, returning 200 only when PostgreSQL is reachable and a generic 503 otherwise;
- align the local Compose database variables and add its missing PostgreSQL healthcheck;
- exclude generated `dist` output from Docker build contexts.

No FUA generation, mapping, patient, or authorization logic changes.

## Safety

- The application no longer drops mapped tables on restart.
- Health failures do not expose database errors or credentials.
- Tests and runtime smoke checks used only synthetic PostgreSQL data.
- No migration, volume, production database, or clinical record is included in this PR.

## Validation

Commit: `9aae9ec`
Environment: DEV (`hii1sc-dev.inf.pucp.edu.pe`)

- **PASSED** — `npm run build`
- **PASSED** — `npx jest --runInBand src/config/databaseConfig.test.ts src/routes/healthRoute.test.ts` (2 suites, 5 tests)
- **PASSED** — `docker compose config --quiet`
- **PASSED** — synthetic PostgreSQL 17 smoke test with distinct canonical database/user/password values
  - `/health`: 200 with PostgreSQL available
  - `/health`: 503 while PostgreSQL was stopped
  - `/health`: recovered to 200 after PostgreSQL restarted
  - 8 mapped tables created
  - mapped table OID preserved across application restart
- **FAILED (pre-existing)** — `npm test -- --runInBand`: `src/utils/sihsalusUtils.test.ts` requires `BACKEND_BASEURL`. The unchanged `f0e3ded` image fails identically; all other existing tests and all new tests pass.

`npm ci` reports inherited dependency findings (2 critical among the current dependency set). Dependencies were intentionally not rewritten in this focused safety fix.

## Deployment note

This commit has not been deployed automatically. PROD currently uses an immutable operational safety derivative of `f0e3ded`; merging and publishing this PR will allow that workaround to be replaced by a source-controlled image after separate deployment approval.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/sihsalus/codesmith/Generador-de-FUA/pr/18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790224861&installation_model_id=22119&pr_number=18&repository=sihsalus%2FGenerador-de-FUA&return_to=https%3A%2F%2Fgithub.com%2Fsihsalus%2FGenerador-de-FUA%2Fpull%2F18&signature=d57a8dd52ac7a2ed11d3a9cb32f198150aaef5a556cdcf954d275a37966f7e21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->